### PR TITLE
Automatically extract API key on startup

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -8,6 +8,7 @@
     <extension point="xbmc.python.pluginsource" library="addon.py">
         <provides>audio</provides>
     </extension>
+    <extension point="xbmc.service" library="service.py" />
     <extension point="xbmc.addon.metadata">
         <summary lang="de_DE">Soundcloud ist eine Online-Audio-Vertriebsplattform.</summary>
 		<summary lang="en_GB">SoundCloud is an online audio distribution platform.</summary>

--- a/resources/lib/kodi/settings.py
+++ b/resources/lib/kodi/settings.py
@@ -21,3 +21,6 @@ class Settings:
 
     def get(self, id):
         return self.addon.getSetting(id)
+
+    def set(self, id, value):
+        return self.addon.setSetting(id, value)

--- a/resources/lib/soundcloud/api_v2.py
+++ b/resources/lib/soundcloud/api_v2.py
@@ -3,6 +3,7 @@ standard_library.install_aliases()  # noqa: E402
 
 import hashlib
 import json
+import re
 import requests
 import urllib.parse
 import xbmc
@@ -231,6 +232,31 @@ class ApiV2(ApiInterface):
         }
 
         return track
+
+    @staticmethod
+    def fetch_client_id():
+        headers = {"Accept-Encoding": "gzip"}
+
+        # Get the HTML (includes a reference to the JS file we need)
+        html = requests.get("https://soundcloud.com/", headers=headers).text
+
+        # Extract the HREF to the JS file (which contains the API key)
+        match = re.search(r"=\"(https://a-v2\.sndcdn\.com/assets/app.*)\"", html)
+
+        if match:
+            # Get the JS
+            response = requests.get(match.group(1), headers=headers)
+            response.encoding = "utf-8"  # This speeds up `response.text` by 3 seconds
+
+            # Extract the API key
+            key = re.search(r"exports={\"api-v2\".*client_id:\"(\w*)\"", response.text)
+
+            if key:
+                return key.group(1)
+            else:
+                raise Exception("Failed to extract client key from js")
+        else:
+            raise Exception("Failed to extract js href from html")
 
     @staticmethod
     def _is_preferred_codec(codec, setting):

--- a/resources/service.py
+++ b/resources/service.py
@@ -1,0 +1,23 @@
+import xbmc
+import xbmcaddon
+from resources.lib.kodi.settings import Settings
+from resources.lib.soundcloud.api_v2 import ApiV2
+
+addon = xbmcaddon.Addon()
+settings = Settings(addon)
+
+
+def run():
+    # Extract tha SoundCloud API key and save it to settings
+    try:
+        api_v2_client_id = ApiV2.fetch_client_id()
+        settings.set("apiv2.clientid", api_v2_client_id)
+        xbmc.log(
+            "plugin.audio.soundcloud::ApiV2() Successfully extracted client id",
+            xbmc.LOGDEBUG
+        )
+    except Exception as exception:
+        xbmc.log(
+            "plugin.audio.soundcloud::ApiV2() " + str(exception),
+            xbmc.LOGDEBUG
+        )

--- a/service.py
+++ b/service.py
@@ -1,0 +1,3 @@
+from resources import service
+
+service.run()


### PR DESCRIPTION
By using a service script, we can execute code on every Kodi startup.
This gives us the possibility to extract the SoundCloud APIv2 key.

This is important, because the APIv2 key periodically changes.