### PR TITLE
Sanitize mobile URLs for API usage

### DIFF
--- a/resources/lib/soundcloud/api_v2.py
+++ b/resources/lib/soundcloud/api_v2.py
@@ -66,6 +66,7 @@ class ApiV2(ApiInterface):
         return self._map_json_to_collection({"collection": res})
 
     def resolve_url(self, url):
+        url = self._sanitize_url(url)
         res = self._do_request("/resolve", {"url": url})
         return self._map_json_to_collection(res)
 
@@ -262,3 +263,7 @@ class ApiV2(ApiInterface):
     def _is_preferred_codec(codec, setting):
         if codec["mime_type"] == setting["mime_type"] and codec["protocol"] == setting["protocol"]:
             return True
+
+    @staticmethod
+    def _sanitize_url(url):
+        return url.replace("m.soundcloud.com/", "soundcloud.com/")

--- a/tests/resources/lib/soundcloud/test_api_v2.py
+++ b/tests/resources/lib/soundcloud/test_api_v2.py
@@ -1,7 +1,7 @@
 import json
 import sys
 from unittest import TestCase
-from unittest.mock import MagicMock, Mock, DEFAULT
+from unittest.mock import MagicMock, Mock, DEFAULT, ANY
 sys.modules['xbmc'] = MagicMock()
 sys.modules['xbmcaddon'] = MagicMock()
 sys.modules['xbmcgui'] = MagicMock()
@@ -83,3 +83,15 @@ class ApiV2TestCase(TestCase):
 
         res = self.api.resolve_id("country blocks suck")
         self.assertEqual(res.items[0].blocked, True)
+
+    def test_resolve_url(self):
+        with open("./tests/mocks/api_v2_resolve_track.json") as f:
+            mock_data = f.read()
+
+        self.api._do_request = Mock(return_value=json.loads(mock_data))
+
+        res = self.api.resolve_url("https://m.soundcloud.com/user/foo")
+        # The SoundCloud APIv2 can't resolve mobile links (m.soundcloud.com), so they have to
+        # be fixed manually. The following assertion is testing this.
+        self.api._do_request.assert_called_with(ANY, {"url": "https://soundcloud.com/user/foo"})
+        self.assertEqual(res.items[0].label, "Thomas Hayden - Universe")


### PR DESCRIPTION
The SoundCloud API can't resolve mobile URLs, so they have to be
manually sanitized. This is important when sharing SoundCloud URLs
from a mobile device.

Resolves #13

### Issues
* When sharing a SoundCloud URL with Yatse, the music is added to a playlist, but does not start to play