### PR TITLE
Fix SoundCloud HLS stream session timeout

### DIFF
--- a/resources/lib/kodi/settings.py
+++ b/resources/lib/kodi/settings.py
@@ -8,6 +8,10 @@ class Settings:
         "1": {
             "mime_type": "audio/mpeg",
             "protocol": "hls",
+        },
+        "2": {
+            "mime_type": "audio/mpeg",
+            "protocol": "progressive",
         }
     }
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -2,7 +2,7 @@
 <settings>
     <category label="30001">
         <setting label="30002" type="lsep"/>
-        <setting id="audio.format" type="enum" label="30003" values="opus (audio/ogg)|mp3 (audio/mpeg)" default="0" />
+        <setting id="audio.format" type="enum" label="30003" values="Opus (HLS)|mp3 (HLS)|mp3 (progressive)" default="2" />
         <setting label="30011" type="lsep"/>
         <setting id="search.items.size" type="labelenum" label="30012" values="5|10|15|20|25|30|40|50" default="20" />
         <setting id="search.history.size" type="labelenum" label="30013" values="0|5|10|15|20|30|50" default="10" />


### PR DESCRIPTION
SoundCloud HLS stream segments contain session keys, which become
invalid after 30 minutes. Because the underlying FFmpeg player doesn't
reload the HLS playlist when this happens, the playback stops after
30 minutes. The SoundCloud website addresses this issue by simply
downloading the m3u8-playlist again if a 403 Forbidden HTTP status code
is encountered, thus obtaining new session keys.

The mp3 progressive encoding seems to be not affected by a session
limit. That's why this audio format is now the new default, even if
it is inferior compared to the previous Opus codec.

Resolves #19