### PR TITLE
Test with actively maintained Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
 
-matrix:
+jobs:
   include:
-    - python: "3.6"
+    - python: "3.7"
+    - python: "3.8"
+    - python: "nightly"
   allow_failures:
     - python: "nightly"
 


### PR DESCRIPTION
Python 3.8 was released recently. Python 3.6 is now in security
releases only mode.