### PR TITLE
Ensure consistent string-encoding for client ID

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.audio.soundcloud" name="SoundCloud" version="4.0.0" provider-name="jaylinski">
+<addon id="plugin.audio.soundcloud" name="SoundCloud" version="4.0.1" provider-name="jaylinski">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.22.0"/>
@@ -18,7 +18,10 @@
         <forum>https://forum.kodi.tv/showthread.php?tid=206635</forum>
         <website>https://soundcloud.com</website>
         <source>https://github.com/jaylinski/kodi-addon-soundcloud</source>
-        <news>4.0.0 (2020-12-12)
+        <news>4.0.1 (2021-11-02)
+Fixed error in "Discover"-folder
+
+4.0.0 (2020-12-12)
 Added support for Kodi v19 (Matrix)
         </news>
         <assets>

--- a/resources/lib/soundcloud/api_v2.py
+++ b/resources/lib/soundcloud/api_v2.py
@@ -54,7 +54,7 @@ class ApiV2(ApiInterface):
 
         # Extract client ID from website and cache it
         client_id = self.fetch_client_id()
-        self.cache.add(self.api_client_id_cache_key, str(client_id))
+        self.cache.add(self.api_client_id_cache_key, client_id)
         xbmc.log("plugin.audio.soundcloud::ApiV2() Using new client ID", xbmc.LOGDEBUG)
 
         return client_id
@@ -112,6 +112,7 @@ class ApiV2(ApiInterface):
         if cache:
             cached_response = self.cache.get(cache_key, cache)
             if cached_response:
+                xbmc.log("plugin.audio.soundcloud::ApiV2() Cache hit", xbmc.LOGDEBUG)
                 return json.loads(cached_response)
 
         # Send the request.
@@ -274,7 +275,7 @@ class ApiV2(ApiInterface):
                 key = re.search(r"exports={\"api-v2\".*client_id:\"(\w*)\"", response.text)
 
                 if key:
-                    return key.group(1)
+                    return str(key.group(1))
 
             raise Exception("Failed to extract client key from js")
         else:


### PR DESCRIPTION
When getting a new client ID, the client ID was returned as a unicode
string instead of an ASCII string. But the client ID was saved as an
ASCII string in the settings.

Since the client ID is part of the request payload and the caching
mechanism, the encoding difference between a new client ID and a cached
client ID resulted in a cache miss (affecting the "discover"-endpoint).
This resulted in weird behaviour and an error in some cases.
By ensuring that the client ID is always an ASCII string we can avoid
this issue.

Fixes #55